### PR TITLE
Fixed encoding requirement with MD5 function  in Python 3

### DIFF
--- a/pyminfraud/transform.py
+++ b/pyminfraud/transform.py
@@ -34,7 +34,7 @@ import hashlib
 			  `` sy"""
 
 def md5(value):
-	return hashlib.md5(value).hexdigest()
+	return hashlib.md5(value.encode('utf-8')).hexdigest()
 
 def bin(value):
 	return value[0:6]


### PR DESCRIPTION
__hashlib.md5__ requires its input to be encoded
otherwise it refuses to work in __Python 3__

@JDBurnZ 