### PR TITLE
Handle latin_1 encoded responses.

### DIFF
--- a/pyminfraud/__init__.py
+++ b/pyminfraud/__init__.py
@@ -171,7 +171,10 @@ class Client:
 
 	def _response_parse(self, response):
 		if sys.version_info >= (3, ):
-			response = response.decode('utf-8')
+			try:
+				response = response.decode('utf-8')
+			except UnicodeError:
+				response = response.decode('latin_1')
 		return dict((key, value) for (key, value) in [row.split('=') for row in response.split(';')]) # Python 2 and 3?
 
 	def _request_arguments(self):


### PR DESCRIPTION
Hey,

Maxmind can also return responses encoded in `latin_1`. this is to handle that.
example response:
```Python
b'distance=0;countryMatch=;countryCode=MX;freeMail=Yes;anonymousProxy=No;binMatch=NA;binCountry=;err=CITY_REQUIRED;proxyScore=0.00;ip_region=22;ip_city=Quer\xe9taro;ip_latitude=20.6000;ip_longitude=-100.3833;binName=;ip_isp=Abastecedora de Conectividad, S.A. de C.V.;ip_org=Abastecedora de Conectividad, S.A. de C.V.;binNameMatch=NA;binPhoneMatch=NA;binPhone=;custPhoneInBillingLoc=;highRiskCountry=No;que'
```

especially this portion.

```
ip_city=Quer\xe9taro;
```