### PR TITLE
Handle warnings by just logging.

### DIFF
--- a/pyminfraud/__init__.py
+++ b/pyminfraud/__init__.py
@@ -18,6 +18,7 @@ __keywords__ = 'python maxmind minfraud pyminfraud'
 # Import standard modules
 import hashlib
 import sys
+import logging
 
 # Import pyminfraud-Specific modules
 from . import exceptions
@@ -27,6 +28,8 @@ from . import transform
 from . import compatibility
 from .documentation import documentation
 from .fields import rules, required, lookup
+
+logger = logging.getLogger('pyminfraud')
 
 request_hosts = [
 	'minfraud.maxmind.com',
@@ -112,7 +115,7 @@ class Client:
 
 		# Check if resulting response contains warnings.
 		if self._response_warnings(self.result):
-			raise exceptions.ResponseWarning(errors.response_warnings[self.result['err']])
+			logger.warn(errors.response_warnings[self.result['err']], extra={'result': self.result})
 
 		return self.result
 

--- a/pyminfraud/exceptions.py
+++ b/pyminfraud/exceptions.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-import warnings
-
 class AuthException(Exception):
 	pass
 
@@ -16,6 +14,3 @@ class MissingRequiredFields(Exception):
 
 class ResponseError(Exception):
 	pass
-
-def ResponseWarning(message):
-	warnings.warn(message, 'UserWarning', stacklevel=2)


### PR DESCRIPTION
Hey,

Since the response with these warnings already contains a riskScore we thought it's not necessary to break the program flow with a warning exception.

Let's discuss this if it doesn't fit another usecase.

@JDBurnZ can you take a look?